### PR TITLE
Fix bug with handling "/" route

### DIFF
--- a/jquery.router.js
+++ b/jquery.router.js
@@ -325,7 +325,7 @@
 
     function handleRoutes(e)
     {
-        if (e != null && e.originalEvent && e.originalEvent.state)
+        if (e != null && e.originalEvent && e.originalEvent.state !== undefined)
         {
             checkRoutes();
         }


### PR DESCRIPTION
When going back to home page through browser's Back button - popstate event triggers, but e.originalEvent.state is NULL, so the router didn't execute the callback
