### PR TITLE
Handle 404's explicitly

### DIFF
--- a/jquery.router.js
+++ b/jquery.router.js
@@ -33,10 +33,14 @@
     var eventAdded = false;
     var currentUsedUrl = location.href; //used for ie to hold the current url
     var firstRoute = true;
+    var errorCallback = function () {};
     
     // hold the latest route that was activated
     router.currentId = "";
     router.currentParameters = {};
+    
+    // Create a default error handler
+    router.errorCallback = errorCallback;
     
     router.capabilities = {
         hash: hasHashState,
@@ -91,6 +95,11 @@
         {
             bindStateEvents();
         }
+    };
+    
+    router.addErrorHandler = function (callback)
+    {
+        this.errorCallback = callback;
     };
     
     function bindStateEvents()
@@ -314,6 +323,12 @@
 
         // check if something is catched
         var actionList = getParameters(currentUrl);
+        
+        // If no routes have been matched
+        if (actionList.length == 0) {
+            // Invoke error handler
+            return router.errorCallback(currentUrl);
+        }
         
         // ietrate trough result (but it will only kick in one)
         for(var i = 0, ii = actionList.length; i < ii; i++)

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,18 @@ Example:
 
 If you need to remove all routes (which is good when testing) you just call:
 
-$.router.reset();
+`$.router.reset();`
+
+### Dealing with 404's
+
+If a url is entered which doesn't fire a route callback (a.k.a. 404 Not Found) you can add your error callback to take that case and make it beautiful.
+
+```js
+$.router.addErrorHandler(function (url) {
+	// url is the URL which the router couldn't find a callback for
+	console.log(url);
+});
+```
 
 ## License 
 


### PR DESCRIPTION
In the current version of the router, 404's are quietly ignored and there is not way to explicitly handle them. This pull request changes that by providing a way to hook into the router and run a callback when no route callbacks are found.

This is a backwards compatible feature addition which does not change existing implementations.